### PR TITLE
github pages workflow for auto-deploy, server script for local build preview

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,63 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy static content to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["release"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      # Step to check out the repository
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Step to set up Node.js (Vite requires Node.js)
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16' # Or the version you need
+
+      # Step to install dependencies
+      - name: Install Dependencies
+        run: npm install
+
+      # Step to run the Vite build
+      - name: Build Vite Project
+        run: npm run build --if-present # Ensure this runs the build script in package.json
+
+      # Step to setup Pages (prepares GitHub Pages deployment)
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      # Upload the build output directory to GitHub Pages (path to dist folder)
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './dist/prod'
+
+      # Step to deploy the files to GitHub Pages
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "legitscript-editor",
       "version": "0.0.0",
       "dependencies": {
-        "monaco-editor": "^0.52.0"
+        "monaco-editor": "^0.52.0",
+        "terser": "^5.36.0"
       },
       "devDependencies": {
         "typescript": "^5.5.3",
@@ -406,6 +407,64 @@
         "node": ">=12"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/set-array": "^1.2.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
+      "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.24.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.24.0.tgz",
@@ -637,6 +696,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/acorn": {
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.13.0.tgz",
+      "integrity": "sha512-8zSiw54Oxrdym50NlZ9sUusyO1Z1ZchgRLWRaK6c86XJFClyCgFKetdowBg5bKxyp/u+CDBJG4Mpp0m3HLZl9w==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
@@ -787,6 +870,15 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -795,6 +887,34 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/terser": {
+      "version": "5.36.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.36.0.tgz",
+      "integrity": "sha512-IYV9eNMuFAV4THUspIRXkLakHnV6XO7FEdtKjf/mDyrnqUg9LnlOn6/RwRvM9SZjR4GUq8Nk8zj67FzVARr74w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.8.2",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "vite": "^5.4.8"
   },
   "dependencies": {
-    "monaco-editor": "^0.52.0"
+    "monaco-editor": "^0.52.0",
+    "terser": "^5.36.0"
   }
 }

--- a/scripts/server.py
+++ b/scripts/server.py
@@ -1,0 +1,47 @@
+# For testing purposes, to preview build as on a 'production' server
+
+from flask import Flask, send_from_directory, redirect
+import argparse
+import os
+import logging
+
+parser = argparse.ArgumentParser(description='Serve files from a custom directory and redirect all requests to URL_NAME')
+parser.add_argument('--host', type=str, default='0.0.0.0', help='Host to listen on (default: 0.0.0.0)')
+parser.add_argument('--port', type=int, default=8000, help='Port to listen on (default: 8000)')
+parser.add_argument('--sdir', choices=['prod', 'dev'], default='prod')
+args = parser.parse_args()
+
+URL_NAME = 'LegitScriptEditor'
+SUBDIR = '../dist/' + args.sdir
+
+app = Flask(__name__)
+logging.basicConfig(level=logging.DEBUG)
+logging.warning(f'Serving "{SUBDIR}" on http://{args.host}:{args.port}')
+
+@app.route('/<path:subpath>', methods=['GET', 'POST'])
+def redirect_to_project(subpath):
+    if subpath.startswith(URL_NAME):
+        return serve_project_files(subpath)
+    return redirect(f'/{URL_NAME}/index.html', code=302)
+
+@app.route('/', methods=['GET', 'POST'])
+def redirect_to_project_root():
+    return redirect(f'/{URL_NAME}/index.html', code=302)
+
+@app.route(f'/{URL_NAME}/<path:filename>', methods=['GET'])
+def serve_project_files(filename):
+    project_dir = SUBDIR 
+
+    file_path = os.path.join(project_dir, filename)
+    index_path = os.path.join(project_dir, filename, 'index.html')
+
+    if os.path.exists(index_path):
+        return send_from_directory(project_dir, 'index.html')
+    elif os.path.exists(file_path):
+        return send_from_directory(project_dir, filename)
+    else:
+        logging.error(f"File not found at: {file_path}")
+        return "File not found", 404
+
+if __name__ == '__main__':
+    app.run(host=args.host, port=args.port)

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,10 @@
+export default {
+  base: '/LegitScriptEditor/',
+  build: {
+    outDir: 'dist/prod',
+    assetsDir: 'assets',
+    minify: 'terser',
+    rollupOptions: {
+    }
+  }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,4 +1,6 @@
-export default {
+import { defineConfig } from 'vite'
+
+export default defineConfig({
   base: '/LegitScriptEditor/',
   build: {
     outDir: 'dist/prod',
@@ -7,4 +9,4 @@ export default {
     rollupOptions: {
     }
   }
-}
+});


### PR DESCRIPTION
There's a vite config and python server script that you might want to merge to main, but I *think* it would probably be a good idea to delete `.github/workflows/deploy.yaml` from any non-release branch, just to make sure GH doesn't start running actions there.

As far as getting automation working - I think you'll need to go to "Settings" -> "Pages" and select "GitHub Actions" if it's not selected already. You'll then need to go to "Settings" -> "Environments" -> "github-pages" and add the release branch to give it permission to run the action and deploy to github.io.