### PR TITLE
Load initial content from github if specified

### DIFF
--- a/src/initial-content.ts
+++ b/src/initial-content.ts
@@ -1,4 +1,4 @@
-export const initialContent = `
+const demoContent = `
 [declaration: "complex"]
 {{
   vec2 complex_sqr(vec2 z) { return vec2(z[0] * z[0] - z[1] * z[1], z[1] * z[0] * 2.); }
@@ -121,3 +121,25 @@ void RenderGraphMain()
   Text("dims: " + sc.GetSize().x + ", " + sc.GetSize().y);
 }}
 `
+
+export async function initialContent(): Promise<string> {
+  const url = new URL(window.location.toString())
+  const github = url.searchParams.get("gh")
+  if (github) {
+    try {
+      const parts = github.split("/")
+      const user = parts.shift()
+      const repo = parts.shift()
+      const rest = parts.join("/")
+      const ref: string = url.searchParams.get("ref") || "master"
+      const req = await fetch(
+        `https://raw.githubusercontent.com/${user}/${repo}/refs/heads/${ref}/${rest}`
+      )
+      return await req.text()
+    } catch {
+      return demoContent
+    }
+  }
+
+  return demoContent
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -400,7 +400,7 @@ async function Init(
 
   const legitScriptCompiler = await LegitScriptCompiler()
 
-  const editor = InitEditor(editorEl)
+  const editor = await InitEditor(editorEl)
   if (!editor) {
     throw new Error("could not initialize monaco")
   }
@@ -527,12 +527,12 @@ function ExecuteFrame(dt: number, state: State) {
   requestAnimationFrame((dt) => ExecuteFrame(dt, state))
 }
 
-function InitEditor(editorEl: HTMLElement) {
+async function InitEditor(editorEl: HTMLElement) {
   if (!editorEl) {
     return
   }
   const editor = monaco.editor.create(editorEl, {
-    value: initialContent || "",
+    value: await initialContent(),
     language: "c",
     minimap: {
       enabled: false,


### PR DESCRIPTION
format is `?gh=<user>/<repo>/path/to/files` with an optional `&ref=...` which can be a sha/tag but will default to `master`

![Screenshot 2024-11-03 at 7 56 26 PM](https://github.com/user-attachments/assets/54f293c6-c52d-41c7-b041-eeecb6370769)
